### PR TITLE
fix: Add Attachment field on ControlType class

### DIFF
--- a/CanvasAppPackager/Poco/App.cs
+++ b/CanvasAppPackager/Poco/App.cs
@@ -88,6 +88,7 @@ namespace CanvasAppPackager.Poco
         public TypeTemplate Template { get; set; }
         public List<ControlType> Type { get; set; }
         public List<string> ProjectionInfoDataSources { get; set; }
+        public ControlThisItemType Attachment { get; set; }
     }
 
     public class ControlThisItemType


### PR DESCRIPTION
This Attachment prop is required for applications witch uses SharePoint as DataSource